### PR TITLE
upgrade dependency to okhttp 3.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,5 +33,5 @@ dependencies {
     compile 'com.esri.arcgis.android:arcgis-android:10.2.7'
     compile 'com.jakewharton.timber:timber:4.1.0'
     compile 'com.squareup.okio:okio:1.6.0'
-    compile 'com.squareup.okhttp:okhttp:2.5.0'
+    compile 'com.squareup.okhttp3:okhttp:3.0.1'
 }

--- a/app/src/main/java/uk/co/snodnipper/okhttp/issue1903/DownloaderImpl.java
+++ b/app/src/main/java/uk/co/snodnipper/okhttp/issue1903/DownloaderImpl.java
@@ -5,13 +5,6 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Environment;
 
-import com.squareup.okhttp.Cache;
-import com.squareup.okhttp.CacheControl;
-import com.squareup.okhttp.Call;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
-
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -20,6 +13,12 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeUnit;
 
+import okhttp3.Cache;
+import okhttp3.CacheControl;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import okio.ByteString;
 import timber.log.Timber;
 
@@ -49,14 +48,16 @@ public class DownloaderImpl implements Downloader {
         }
 
 
-        mClient = new OkHttpClient();
         File cacheDirectory = new File(
                 rootLocation +
                         File.separator + "esri-maps-cache" + File.separator + "streaming");
         long cacheSize = 1024 * 1024 * 250L * 1024L * 1024L;
 
         mCache = new Cache(cacheDirectory, cacheSize);
-        mClient.setCache(mCache);
+
+        mClient = new OkHttpClient.Builder()
+                .cache(mCache)
+                .build();
 
         // cache control
         mCacheControl = new CacheControl.Builder()
@@ -131,19 +132,11 @@ public class DownloaderImpl implements Downloader {
             }
 
             if (resp != null && resp.body() != null) {
-                try {
-                    resp.body().close();
-                } catch (IOException e2) {
-                    Timber.e(e2, "Potential leak - cannot close body");
-                }
+                resp.body().close();
             }
         } finally {
             if (resp != null && resp.body() != null) {
-                try {
-                    resp.body().close();
-                } catch (IOException e) {
-                    Timber.e(e, "Potential leak - cannot close body");
-                }
+                resp.body().close();
             }
         }
 


### PR DESCRIPTION
Same 

01-17 20:36:32.139  4512  4549 E StrictMode: java.lang.Throwable: Explicit termination method 'end' not called
01-17 20:36:32.139  4512  4549 E StrictMode:    at dalvik.system.CloseGuard.open(CloseGuard.java:180)
01-17 20:36:32.139  4512  4549 E StrictMode:    at java.util.zip.Inflater.<init>(Inflater.java:82)
01-17 20:36:32.139  4512  4549 E StrictMode:    at java.util.zip.ZipFile.getInputStream(ZipFile.java:343)
01-17 20:36:32.139  4512  4549 E StrictMode:    at java.util.jar.JarFile.getInputStream(JarFile.java:390)
01-17 20:36:32.139  4512  4549 E StrictMode:    at libcore.net.url.JarURLConnectionImpl.getInputStream(JarURLConnectionImpl.java:222)
01-17 20:36:32.139  4512  4549 E StrictMode:    at java.net.URL.openStream(URL.java:470)
01-17 20:36:32.139  4512  4549 E StrictMode:    at java.lang.ClassLoader.getResourceAsStream(ClassLoader.java:444)
01-17 20:36:32.139  4512  4549 E StrictMode:    at java.lang.Class.getResourceAsStream(Class.java:1169)
01-17 20:36:32.139  4512  4549 E StrictMode:    at com.esri.android.map.MapView$a.a(SourceFile:3321)
01-17 20:36:32.139  4512  4549 E StrictMode:    at com.esri.android.map.MapView$a.b(SourceFile:3311)
01-17 20:36:32.139  4512  4549 E StrictMode:    at com.esri.android.map.MapView$a.a(SourceFile:3277)
01-17 20:36:32.139  4512  4549 E StrictMode:    at com.esri.android.map.MapView$a.a(SourceFile:3229)
01-17 20:36:32.139  4512  4549 E StrictMode:    at com.esri.android.map.MapView$7.run(SourceFile:3114)
01-17 20:36:32.139  4512  4549 E StrictMode:    at android.os.Handler.handleCallback(Handler.java:739)
01-17 20:36:32.139  4512  4549 E StrictMode:    at android.os.Handler.dispatchMessage(Handler.java:95)
01-17 20:36:32.139  4512  4549 E StrictMode:    at android.os.Looper.loop(Looper.java:148)
01-17 20:36:32.139  4512  4549 E StrictMode:    at android.app.ActivityThread.main(ActivityThread.java:5417)
01-17 20:36:32.139  4512  4549 E StrictMode:    at java.lang.reflect.Method.invoke(Native Method)
01-17 20:36:32.139  4512  4549 E StrictMode:    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
01-17 20:36:32.139  4512  4549 E StrictMode:    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
01-17 20:36:32.149  4512  4549 E StrictMode: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
01-17 20:36:32.149  4512  4549 E StrictMode: java.lang.Throwable: Explicit termination method 'close' not called
01-17 20:36:32.149  4512  4549 E StrictMode:    at dalvik.system.CloseGuard.open(CloseGuard.java:180)
01-17 20:36:32.149  4512  4549 E StrictMode:    at java.io.FileOutputStream.<init>(FileOutputStream.java:89)
01-17 20:36:32.149  4512  4549 E StrictMode:    at java.io.FileOutputStream.<init>(FileOutputStream.java:72)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okio.Okio.sink(Okio.java:176)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.internal.io.FileSystem$1.sink(FileSystem.java:49)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.internal.DiskLruCache$Editor.newSink(DiskLruCache.java:863)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.Cache$CacheRequestImpl.<init>(Cache.java:437)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.Cache.put(Cache.java:250)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.Cache.access$000(Cache.java:136)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.Cache$1.put(Cache.java:148)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.internal.http.HttpEngine.maybeCache(HttpEngine.java:389)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.internal.http.HttpEngine.readResponse(HttpEngine.java:633)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.RealCall.getResponse(RealCall.java:241)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.RealCall$ApplicationInterceptorChain.proceed(RealCall.java:198)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:160)
01-17 20:36:32.149  4512  4549 E StrictMode:    at okhttp3.RealCall.execute(RealCall.java:57)
01-17 20:36:32.149  4512  4549 E StrictMode:    at uk.co.snodnipper.okhttp.issue1903.DownloaderImpl.getData(DownloaderImpl.java:116)
01-17 20:36:32.149  4512  4549 E StrictMode:    at uk.co.snodnipper.okhttp.issue1903.MapboxLayer.getTile(MapboxLayer.java:117)
01-17 20:36:32.149  4512  4549 E StrictMode:    at com.esri.android.map.TiledServiceLayer$1.run(SourceFile:412)
01-17 20:36:32.149  4512  4549 E StrictMode:    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:423)
01-17 20:36:32.149  4512  4549 E StrictMode:    at java.util.concurrent.FutureTask.run(FutureTask.java:237)
01-17 20:36:32.149  4512  4549 E StrictMode:    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
01-17 20:36:32.149  4512  4549 E StrictMode:    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
01-17 20:36:32.149  4512  4549 E StrictMode:    at java.lang.Thread.run(Thread.java:818)
